### PR TITLE
fix inet_dist_interface

### DIFF
--- a/ecs/bin/ejabberdctl
+++ b/ecs/bin/ejabberdctl
@@ -83,7 +83,7 @@ if [ -n "$FIREWALL_WINDOW" ] ; then
     ERLANG_OPTS="$ERLANG_OPTS -kernel inet_dist_listen_min ${FIREWALL_WINDOW%-*} inet_dist_listen_max ${FIREWALL_WINDOW#*-}"
 fi
 if [ -n "$INET_DIST_INTERFACE" ] ; then
-    INET_DIST_INTERFACE2=$("$ERL" -noshell -eval 'case inet:parse_address("'$INET_DIST_INTERFACE'") of {ok,IP} -> io:format("~p",[IP]); _ -> ok end.' -s erlang halt)
+    INET_DIST_INTERFACE2=$("$ERL" -boot start_clean -noshell -eval 'case inet:parse_address("'$INET_DIST_INTERFACE'") of {ok,IP} -> io:format("~p",[IP]); _ -> ok end.' -s erlang halt)
     if [ -n "$INET_DIST_INTERFACE2" ] ; then
         ERLANG_OPTS="$ERLANG_OPTS -kernel inet_dist_use_interface $INET_DIST_INTERFACE2"
     fi


### PR DESCRIPTION
I found that adding `-boot start_clean` to `ejabberdctl` was necessary in order to make `INET_DIST_INTERFACE` work again.