### PR TITLE
STUN/TURN & SIP

### DIFF
--- a/ecs/conf/ejabberd.yml
+++ b/ecs/conf/ejabberd.yml
@@ -86,6 +86,55 @@ listen:
     ip: "::"
     module: mod_mqtt
     backlog: 1000
+  ##
+  ## https://docs.ejabberd.im/admin/configuration/#stun-and-turn
+  ## ejabberd_stun: Handles STUN Binding requests
+  ##
+  ##-
+  ##  port: 3478
+  ##  ip: "0.0.0.0"
+  ##  transport: udp
+  ##  module: ejabberd_stun
+  ##  use_turn: true
+  ##  turn_ip: "{{ IP }}"
+  ##  auth_type: user
+  ##  auth_realm: "example.com"
+  ##-
+  ##  port: 3478
+  ##  ip: "0.0.0.0"
+  ##  module: ejabberd_stun
+  ##  use_turn: true
+  ##  turn_ip: "{{ IP }}"
+  ##  auth_type: user
+  ##  auth_realm: "example.com"
+  ##- 
+  ##  port: 5349
+  ##  ip: "0.0.0.0"
+  ##  module: ejabberd_stun
+  ##  certfile: "/home/ejabberd/conf/server.pem"
+  ##  tls: true
+  ##  use_turn: true
+  ##  turn_ip: "{{ IP }}"
+  ##  auth_type: user
+  ##  auth_realm: "example.com"
+  ##
+  ## https://docs.ejabberd.im/admin/configuration/#sip
+  ## To handle SIP (VOIP) requests:
+  ##
+  ##-
+  ##  port: 5060
+  ##  ip: "0.0.0.0"
+  ##  transport: udp
+  ##  module: ejabberd_sip
+  ##-
+  ##  port: 5060
+  ##  ip: "0.0.0.0"
+  ##  module: ejabberd_sip
+  ##-
+  ##  port: 5061
+  ##  ip: "0.0.0.0"
+  ##  module: ejabberd_sip
+  ##  tls: true
 
 s2s_use_starttls: optional
 
@@ -234,6 +283,7 @@ modules:
     ip_access: trusted_network
   mod_roster:
     versioning: true
+  mod_sip: {}
   mod_s2s_dialback: {}
   mod_shared_roster: {}
   mod_stream_mgmt:

--- a/ecs/vars.config
+++ b/ecs/vars.config
@@ -6,3 +6,5 @@
 {zlib, true}.
 {elixir, true}.
 {iconv, true}.
+{stun, true}.
+{sip, true}.


### PR DESCRIPTION
:wrench: Enable STUN/TURN and SIP by default

I would understand if you do not want to add all modules in the docker container, but I was forced to fork the repo just to enable this so I feel like I should at least share the idea 😉 