### PR TITLE
Add badges and links to docker README

### DIFF
--- a/ecs/README.md
+++ b/ecs/README.md
@@ -1,3 +1,10 @@
+
+[![Docker Stars](https://img.shields.io/docker/stars/ejabberd/ecs.svg)](https://hub.docker.com/r/ejabberd/ecs/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/ejabberd/ecs.svg)](https://hub.docker.com/r/ejabberd/ecs/)
+[![](https://images.microbadger.com/badges/version/ejabberd/ecs.svg)](https://microbadger.com/images/ejabberd/ecs)
+[![](https://images.microbadger.com/badges/image/ejabberd/ecs.svg)](https://microbadger.com/images/ejabberd/ecs)
+[![GitHub stars](https://img.shields.io/github/stars/processone/docker-ejabberd.svg?style=social)](https://github.com/processone/docker-ejabberd)
+
 ## ejabberd Community Server - Base
 
 This ejabberd Docker image allows you to run a single node ejabberd instance in a Docker container.

--- a/mix/README.md
+++ b/mix/README.md
@@ -1,3 +1,10 @@
+
+[![Docker Stars](https://img.shields.io/docker/stars/ejabberd/mix.svg)](https://hub.docker.com/r/ejabberd/mix/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/ejabberd/mix.svg)](https://hub.docker.com/r/ejabberd/mix/)
+[![](https://images.microbadger.com/badges/version/ejabberd/mix.svg)](https://microbadger.com/images/ejabberd/mix)
+[![](https://images.microbadger.com/badges/image/ejabberd/mix.svg)](https://microbadger.com/images/ejabberd/mix)
+[![GitHub stars](https://img.shields.io/github/stars/processone/docker-ejabberd.svg?style=social)](https://github.com/processone/docker-ejabberd)
+
 ## Docker image for ejabberd developers
 
 Thanks to this image, you can build ejabberd with dependencies provided in Docker image, without the need to install build software (beside Docker) directly on your own machine.


### PR DESCRIPTION
:memo: Add badges and links to docker README. It gives a little bit of info and saves the time to find the link to GitHub / DockerHub