### PR TITLE
Fix the sample Let's Encrypt configuration

### DIFF
--- a/ecs/conf/ejabberd.yml
+++ b/ecs/conf/ejabberd.yml
@@ -38,10 +38,15 @@ log_rate_limit: 100
 
 certfiles:
   - "/home/ejabberd/conf/server.pem"
-##  - "/etc/letsencrypt/live/localhost/fullchain.pem"
-##  - "/etc/letsencrypt/live/localhost/privkey.pem"
 
 ca_file: "/home/ejabberd/conf/cacert.pem"
+
+# When using let's encrypt to generate certificates
+##certfiles:
+##  - "/etc/letsencrypt/live/localhost/cert.pem"
+##  - "/etc/letsencrypt/live/localhost/privkey.pem"
+##
+##ca_file: "/etc/letsencrypt/live/localhost/fullchain.pem"
 
 listen:
   -


### PR DESCRIPTION
:memo: Fix the sample Let's Encrypt configuration

From the Let's encrypt doc and my own, tests, the sample let's encrypt config is incorrect as `fullchain.pem` is the CA file.