### PR TITLE
Keep SQL init scripts in container

### DIFF
--- a/ecs/Dockerfile
+++ b/ecs/Dockerfile
@@ -66,6 +66,7 @@ RUN apk upgrade --update musl \
 # Install ejabberd
 WORKDIR $HOME
 COPY --from=builder /ejabberd/runtime .
+COPY --from=builder /ejabberd/sql /usr/src/ejabberd/sql
 COPY bin/* bin/
 RUN chmod 755 bin/ejabberdctl bin/ejabberdapi bin/erl
 COPY --chown=ejabberd:ejabberd conf conf/

--- a/ecs/Dockerfile
+++ b/ecs/Dockerfile
@@ -74,7 +74,7 @@ ADD --chown=ejabberd:ejabberd https://download.process-one.net/cacert.pem conf/c
 
 # Setup runtime environment
 USER ejabberd
-VOLUME ["$HOME/database","$HOME/conf","$HOME/logs", /usr/src/ejabberd/]
+VOLUME ["$HOME/database","$HOME/conf","$HOME/logs","/usr/src/ejabberd/"]
 EXPOSE 1883 4369-4399 5222 5269 5280 5443
 
 ENTRYPOINT ["/home/ejabberd/bin/ejabberdctl"]

--- a/ecs/Dockerfile
+++ b/ecs/Dockerfile
@@ -74,7 +74,7 @@ ADD --chown=ejabberd:ejabberd https://download.process-one.net/cacert.pem conf/c
 
 # Setup runtime environment
 USER ejabberd
-VOLUME ["$HOME/database","$HOME/conf","$HOME/logs"]
+VOLUME ["$HOME/database","$HOME/conf","$HOME/logs", /usr/src/ejabberd/]
 EXPOSE 1883 4369-4399 5222 5269 5280 5443
 
 ENTRYPOINT ["/home/ejabberd/bin/ejabberdctl"]

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -105,6 +105,7 @@ Here are the volume you may want to map:
 - /home/ejabberd/logs/: Directory containing log files
 - /home/ejabberd/database/: Directory containing Mnesia database. You should back up or export the content of the directory to persistent storage (host storage, local storage, any storage plugin)
 - /home/ejabberd/conf/: Directory containing configuration and certificates
+- /usr/src/ejabberd/sql: Directory containing SQL install scripts
 
 All these files are owned by ejabberd user inside the container. Corresponding
 UID:GID is 9000:9000. If you prefer bind mounts instead of docker volumes, then


### PR DESCRIPTION
:sparkles: Keep SQL init scripts in container

Just an idea so far, but I'm thinking it might be helpful to provide in the final container the SQL scripts for the current ejabberd version as it would prevent you to download them yourself (and mess things up by downloading the wrong version).

The sql scripts are stored in `/usr/src/ejabberd/sql`.
You could access them by sharing volumes between your database and ejabberd (`volumes_from` with docker-compose) or create shared volume between containers and copy the scripts to it.

What do you think ?