### PR TITLE
Dockerhub build hook 

### DIFF
--- a/ecs/hooks/build
+++ b/ecs/hooks/build
@@ -6,4 +6,9 @@
 # Use $VERSION build environment variable or the Docker repository tag being built
 version=${VERSION:-${DOCKER_TAG}}
 
-docker build --build-arg VERSION=$version -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+docker build \
+    --build-arg VERSION=$version \
+    --build-arg VCS_REF=`git rev-parse --short HEAD` \
+    --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+    -f $DOCKERFILE_PATH \
+    -t $IMAGE_NAME .

--- a/ecs/hooks/build
+++ b/ecs/hooks/build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# See documentation for details:
+# https://docs.docker.com/docker-hub/builds/advanced/
+
+# Use $VERSION build environment variable or the Docker repository tag being built
+version=${VERSION:-${DOCKER_TAG}}
+
+docker build --build-arg VERSION=$version -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
:construction_worker: Dockerhub build hook (https://docs.docker.com/docker-hub/builds/advanced/)

This will allow you to link github repo to dockerhub and enable automated builds:
* the `VERSION` will be automatically set with the docker tag being built
* the build hook will pass the `VERSION` build arg when building images

With this, you can easily build and maintain different versions of ejabberd with the same repository simply by creating the tags in docker cloud:
![image](https://user-images.githubusercontent.com/6967675/61375445-37be5e00-a89f-11e9-804e-d0f7e303672d.png)


NOTE: the build hook will need to be updated if #40 is merged