### PR TITLE
enable odbc

### DIFF
--- a/ecs/Dockerfile
+++ b/ecs/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir runtime \
  && cp -r /ejabberd/sql lib/ejabberd-*/priv
 
 # Runtime container
-FROM alpine:3.9
+FROM alpine:3.11
 ARG VERSION
 ARG VCS_REF
 ARG BUILD_DATE
@@ -63,6 +63,7 @@ RUN addgroup ejabberd -g 9000 \
 RUN apk upgrade --update musl \
  && apk add \
     expat \
+    freetds \
     gd \
     jpeg \
     libgd \
@@ -76,6 +77,7 @@ RUN apk upgrade --update musl \
     unixodbc \
     yaml \
     zlib \
+ && ln -fs /usr/lib/libtdsodbc.so.0 /usr/lib/libtdsodbc.so \
  && rm -rf /var/cache/apk/*
 
 # Install ejabberd

--- a/ecs/vars.config
+++ b/ecs/vars.config
@@ -1,4 +1,5 @@
 {mysql, true}.
+{odbc, true}.
 {pgsql, true}.
 {sqlite, true}.
 {redis, true}.

--- a/mix/Dockerfile
+++ b/mix/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.11
 LABEL maintainer="ProcessOne <contact@process-one.net>" \
       product="Ejabberd mix development environment"
 
@@ -8,7 +8,7 @@ RUN apk upgrade --update musl \
             gd-dev jpeg-dev libpng-dev libwebp-dev autoconf automake bash \
             elixir erlang-crypto erlang-eunit erlang-mnesia erlang-erts erlang-hipe \
             erlang-tools erlang-os-mon erlang-syntax-tools erlang-parsetools \
-            erlang-runtime-tools erlang-reltool file curl \
+            erlang-runtime-tools erlang-reltool erlang-odbc file curl \
  && rm -rf /var/cache/apk/*
 
 # Setup runtime environment


### PR DESCRIPTION
This PR makes ist possible to use odbc database connections and mssql with docker-ejabberd.

See https://github.com/processone/docker-ejabberd/issues/50 and https://github.com/processone/ejabberd/pull/3125.

I also propose to upgrade to alpine 3.11 for newer freeTDS driver.