### PR TITLE
Use exec so that signals reach the actual process

### DIFF
--- a/ecs/bin/ejabberdctl
+++ b/ecs/bin/ejabberdctl
@@ -119,7 +119,7 @@ exec_cmd()
 {
     case $EXEC_CMD in
         as_install_user) su -s /bin/sh -c '"$0" "$@"' "$INSTALLUSER" -- "$@" ;;
-        as_current_user) "$@" ;;
+        as_current_user) exec "$@" ;;
     esac
 }
 exec_erl()


### PR DESCRIPTION
Currently, signals are not forwarded to ejabberd, because it's a child of `sh`. When trying to stop the container the process will not exit until it is killed.