### PR TITLE
Update ACME default `ca_url`

### DIFF
--- a/ecs/conf/ejabberd.yml
+++ b/ecs/conf/ejabberd.yml
@@ -201,7 +201,7 @@ max_fsm_queue: 10000
 
 acme:
    contact: "mailto:example-admin@example.com"
-   ca_url: "https://acme-v01.api.letsencrypt.org"
+   ca_url: "https://acme-staging-v02.api.letsencrypt.org/directory"
 
 modules:
   mod_adhoc: {}


### PR DESCRIPTION
The current default **ca_url** (`https://acme-v01.api.letsencrypt.org`) rely on ACME v1 which had been deprecated.