### PR TITLE
Use modern alpine

### DIFF
--- a/mix/Dockerfile
+++ b/mix/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.15
 LABEL maintainer="ProcessOne <contact@process-one.net>" \
       product="Ejabberd mix development environment"
 


### PR DESCRIPTION
Your version of alpine is two years out of date and has some security and library problems.  This replaces 3.11 with 3.15

I did not independently test this change because I don't actually know how