### PR TITLE
ecs/Dockerfile: add tini as runtime init

### DIFF
--- a/ecs/Dockerfile
+++ b/ecs/Dockerfile
@@ -82,6 +82,7 @@ RUN apk upgrade --update musl \
     openssl \
     sqlite \
     sqlite-libs \
+    tini \
     unixodbc \
     yaml \
     zlib \
@@ -101,5 +102,5 @@ USER ejabberd
 VOLUME ["$HOME/database","$HOME/conf","$HOME/logs","$HOME/upload"]
 EXPOSE 1883 4369-4399 5222 5269 5280 5443
 
-ENTRYPOINT ["/home/ejabberd/bin/ejabberdctl"]
+ENTRYPOINT ["/sbin/tini","--","/home/ejabberd/bin/ejabberdctl"]
 CMD ["foreground"]

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -25,7 +25,7 @@ If you are using a Windows operating system, check the tutorials mentioned in
 You can start ejabberd in a new container with the following command:
 
 ```bash
-docker run --name ejabberd -d -p 5222:5222 --init ejabberd/ecs
+docker run --name ejabberd -d -p 5222:5222 ejabberd/ecs
 ```
 
 This command will run Docker image as a daemon,
@@ -48,7 +48,7 @@ docker restart ejabberd
 If you would like to start ejabberd with an Erlang console attached you can use the `live` command:
 
 ```bash
-docker run -it -p 5222:5222 --init ejabberd/ecs live
+docker run -it -p 5222:5222 ejabberd/ecs live
 ```
 
 This command will use default configuration file and XMPP domain "localhost".
@@ -60,7 +60,7 @@ and share local directory to store database:
 
 ```bash
 mkdir database
-docker run -d --name ejabberd -v $(pwd)/ejabberd.yml:/home/ejabberd/conf/ejabberd.yml -v $(pwd)/database:/home/ejabberd/database -p 5222:5222 --init ejabberd/ecs
+docker run -d --name ejabberd -v $(pwd)/ejabberd.yml:/home/ejabberd/conf/ejabberd.yml -v $(pwd)/database:/home/ejabberd/database -p 5222:5222 ejabberd/ecs
 ```
 
 # Next steps


### PR DESCRIPTION
- no need to start with flag `--init` anymore as introduced here 90671eb93f8812fa74281accde2363a170cb47cd
- should close issue #89