### PR TITLE
fix: invalid CTL_ON_CREATE usage in docker-compose example

### DIFF
--- a/ecs/README.md
+++ b/ecs/README.md
@@ -226,7 +226,7 @@ abort start, this can be disabled by prefixing commands with `!`
 Example usage (or check the [full example](#customized-example)):
 ```yaml
     environment:
-      - CTL_ON_CREATE=\! register admin localhost asd
+      - CTL_ON_CREATE=! register admin localhost asd
       - CTL_ON_START=stats registeredusers ;
                      check_password admin localhost asd ;
                      status
@@ -513,7 +513,7 @@ services:
     environment:
       - ERLANG_NODE_ARG=ejabberd@main
       - ERLANG_COOKIE=dummycookie123
-      - CTL_ON_CREATE=\! register admin localhost asd
+      - CTL_ON_CREATE=! register admin localhost asd
     healthcheck:
       test: netstat -nl | grep -q 5222
       start_period: 5s


### PR DESCRIPTION
Hey, this is the exact same change that I have opened a PR for here: https://github.com/processone/ejabberd/pull/4205

Let me know if you need me to provide more details or something does not look right. Thanks for the great docker image!