### PR TITLE
Allow commit/branch to be build

### DIFF
--- a/ecs/Dockerfile
+++ b/ecs/Dockerfile
@@ -14,10 +14,16 @@ LABEL maintainer="ProcessOne <contact@process-one.net>" \
 RUN git clone https://github.com/processone/ejabberd.git
 WORKDIR /ejabberd
 COPY vars.config .
-RUN echo '{vsn, "'${VERSION}'.0"}.' >>vars.config
 COPY config.exs config/
 COPY rel/*exs rel/
 RUN git checkout ${VERSION/latest/HEAD} \
+    \
+    && if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then \
+        echo '{vsn, "'"$VERSION.0"'"}.' >> vars.config; \
+    else \
+        echo '{vsn, "0.0.0"}.' >> vars.config; \
+    fi \
+    \
     && mix deps.get \
     && (cd deps/eimp; ./configure)
 


### PR DESCRIPTION
This PR allow building a branch or commit hash. Version is set to 0.0.0 if `VERSION` doesn't match a version string.

e.g.

```
docker buildx build --build-arg VERSION=a19ab9f4e3586d6298f739b88b9e624bc282f815 ecs/
```

// Edit: just changed commit author email address